### PR TITLE
Added "auto" account type and related comment codes: "I" "AB" "AO" "AZ" "BI" "BJ" "BK"

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,12 @@
+# The behavior of RuboCop can be controlled via the .rubocop.yml
+# configuration file. It makes it possible to enable/disable
+# certain cops (checks) and to alter their behavior if they accept
+# any parameters. The file can be placed either in your home
+# directory or in some project directory.
+#
+# RuboCop will start looking for the configuration file in the directory
+# where the inspected file is and continue its way up to the root directory.
+#
+# See https://github.com/rubocop-hq/rubocop/blob/master/manual/configuration.md
+Layout/LineLength:
+  Max: 100

--- a/lib/metro_2/version.rb
+++ b/lib/metro_2/version.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 module Metro2
-  VERSION = "1.2.3"
+  VERSION = '1.2.4'
 
   def self.version_string
     str = VERSION.split('.')

--- a/metro_2.gemspec
+++ b/metro_2.gemspec
@@ -1,24 +1,25 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+# frozen_string_literal: true
+
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'metro_2/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "metro_2"
+  spec.name          = 'metro_2'
   spec.version       = Metro2::VERSION
-  spec.authors       = ["Brian Mascarenhas"]
-  spec.email         = ["brian@upstart.com"]
-  spec.summary       = "Create Metro 2 format files for credit reporting"
-  spec.description   = "Create Metro 2 format files for credit reporting"
-  spec.homepage      = ""
-  spec.license       = "MIT"
+  spec.authors       = ['Brian Mascarenhas']
+  spec.email         = ['brian@upstart.com']
+  spec.summary       = 'Create Metro 2 format files for credit reporting'
+  spec.description   = 'Create Metro 2 format files for credit reporting'
+  spec.homepage      = ''
+  spec.license       = 'MIT'
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
-  spec.add_development_dependency "bundler", "~> 1.6"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 2.13"
+  spec.add_development_dependency 'bundler', '~> 2.1'
+  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rspec', '~> 2.13'
 end

--- a/spec/records/header_segment_spec.rb
+++ b/spec/records/header_segment_spec.rb
@@ -32,7 +32,7 @@ describe Metro2::Records::HeaderSegment do
         '123 Report Dr Address CA 91111'.ljust(96, ' '),
         '5555555555',
         'Upstart Engineer metro 2 gem'.ljust(40, ' '),
-        '01203',
+        '01204',
         ' ' * 156
       ]
       header_str = @header.to_metro2


### PR DESCRIPTION
Added "auto" account type and related comment codes:

```
auto: '00',
...
election_of_remedy: 'I',
paid_through_insurance: 'AB',
voluntarily_surrendered: 'AO',
redeemed_or_reinstated_repossession: 'AZ',
involuntary_repossession: 'BI',
involuntary_repossession_obligation_satisfied: 'BJ',
involuntary_repossession_balance_owing: 'BK'
```